### PR TITLE
Desenvolvimento

### DIFF
--- a/apps/api/ANALISE_MODULOS_API.md
+++ b/apps/api/ANALISE_MODULOS_API.md
@@ -1,5 +1,6 @@
 # Análise Completa dos Módulos da API
 
+
 ## 📋 Resumo Executivo
 
 Esta análise examina todos os módulos da API NestJS para identificar problemas de organização,

--- a/apps/web/src/lib/repositories/TurnoRepository.ts
+++ b/apps/web/src/lib/repositories/TurnoRepository.ts
@@ -29,10 +29,9 @@ export type TurnoCreateInput = {
 
 /**
  * Tipo para dados de atualização de turno
+ * Nota: O id não está incluído aqui porque é passado separadamente no método update
  */
-export type TurnoUpdateInput = Partial<TurnoCreateInput> & {
-  id: number;
-};
+export type TurnoUpdateInput = Partial<TurnoCreateInput>;
 
 export class TurnoRepository extends AbstractCrudRepository<Turno, TurnoFilter> {
   /**
@@ -94,8 +93,8 @@ export class TurnoRepository extends AbstractCrudRepository<Turno, TurnoFilter> 
     data: TurnoUpdateInput,
     userId?: string
   ): Promise<Turno> {
-    // Remover id e eletricistaIds do objeto de dados (id vai no where, eletricistaIds é tratado separadamente)
-    const { id: _, eletricistaIds, kmFim, ...turnoData } = data;
+    // Remover eletricistaIds do objeto de dados (eletricistaIds é tratado separadamente)
+    const { eletricistaIds, kmFim, ...turnoData } = data;
 
     // Preparar dados para o Prisma (mapear kmFim para KmFim)
     const prismaData: any = {

--- a/apps/web/src/ui/components/FecharTurnoModal.tsx
+++ b/apps/web/src/ui/components/FecharTurnoModal.tsx
@@ -171,7 +171,10 @@ export default function FecharTurnoModal({
             placeholder="Informe o KM final"
             min={turno.kmInicio}
             formatter={(value) => `${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
-            parser={(value) => value!.replace(/\s?\./g, '')}
+            parser={(value) => {
+              const parsed = value!.replace(/\s?\./g, '');
+              return parsed ? Number(parsed) : 0;
+            }}
           />
         </Form.Item>
       </Form>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Separates `id` from Turno update input and adjusts repository update; improves KM Final input parsing to return a number (default 0); minor API analysis doc tweak.
> 
> - **Web**
>   - **Repository (`apps/web/src/lib/repositories/TurnoRepository.ts`)**:
>     - Refactors `TurnoUpdateInput` to exclude `id` (now passed separately to `update(id, data, ...)`).
>     - Simplifies `update` destructuring to omit only `eletricistaIds` and `kmFim`.
>   - **UI (`apps/web/src/ui/components/FecharTurnoModal.tsx`)**:
>     - Improves `InputNumber` `parser` for `kmFim` to return a numeric value and default to `0` when empty.
> - **Docs**
>   - Minor update to `apps/api/ANALISE_MODULOS_API.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cfa633663a651b1b6504ae617061de4fb591f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->