### PR TITLE
Desenvolvimento

### DIFF
--- a/ANALISE_ERRO_PRODUCAO.md
+++ b/ANALISE_ERRO_PRODUCAO.md
@@ -12,7 +12,7 @@ O app mobile tentou fechar um turno que **já estava fechado** (Turno ID: 950, f
 ### Comportamento do Sistema
 O sistema detectou que o turno já estava fechado e retornou:
 - **Status HTTP**: `409 Conflict` (correto para indicar conflito de estado)
-- **Response**: 
+- **Response**:
   ```json
   {
     "status": "already_closed",

--- a/ANALISE_ERRO_PRODUCAO.md
+++ b/ANALISE_ERRO_PRODUCAO.md
@@ -1,0 +1,111 @@
+# 🔍 Análise do "Erro" em Produção
+
+## 📋 Resumo
+
+**Este NÃO é um erro real!** É um comportamento esperado e válido do sistema.
+
+## 🔍 O que está acontecendo?
+
+### Situação
+O app mobile tentou fechar um turno que **já estava fechado** (Turno ID: 950, fechado em 2025-12-05).
+
+### Comportamento do Sistema
+O sistema detectou que o turno já estava fechado e retornou:
+- **Status HTTP**: `409 Conflict` (correto para indicar conflito de estado)
+- **Response**: 
+  ```json
+  {
+    "status": "already_closed",
+    "remoteId": 950,
+    "closedAt": "2025-12-05T13:32:16.974Z",
+    "kmFinal": 26420
+  }
+  ```
+
+### Por que isso acontece?
+1. **Sincronização Mobile**: O app mobile pode tentar fechar um turno que já foi fechado (ex: tentativa de sincronização após perda de conexão)
+2. **Comportamento Esperado**: O sistema retorna HTTP 409 com informações para o app sincronizar seus dados locais
+3. **Não é um erro**: É uma resposta válida que permite ao app mobile atualizar seu estado local
+
+## 📍 Onde está o código?
+
+**Arquivo**: `apps/api/src/modules/turno/controllers/turno-mobile.controller.ts`
+
+**Linhas 343-356**:
+```typescript
+// Verificar se o turno já estava fechado (retorno especial do service)
+if (turnoResult && (turnoResult as any)._alreadyClosed) {
+  this.logger.log(`Turno já estava fechado: ID ${turnoResult.id}`);
+  // Retornar HTTP 409 com formato JSON específico para o app sincronizar
+  throw new HttpException(
+    {
+      status: 'already_closed',
+      remoteId: turnoResult.id,
+      closedAt: turnoResult.dataFim?.toISOString() || new Date().toISOString(),
+      kmFinal: (turnoResult as any).KmFim || null,
+    },
+    HttpStatus.CONFLICT
+  );
+}
+```
+
+## ⚠️ Problema Identificado
+
+O `AllExceptionsFilter` está logando **todos** os HttpExceptions com status 400-499 como **WARNING**, incluindo este caso que é um comportamento esperado.
+
+**Arquivo**: `apps/api/src/common/filters/all-exceptions.filter.ts`
+
+**Linha 172-173**:
+```typescript
+} else if (status >= 400) {
+  this.logger.warn(`[${status}] ${request.method} ${request.url} - ${JSON.stringify(safeMessage)}`);
+}
+```
+
+Isso faz com que casos válidos como "turno já fechado" apareçam nos logs como se fossem problemas.
+
+## ✅ Solução Recomendada
+
+Ajustar o filtro para **não logar como warning** quando for um HTTP 409 com `status: 'already_closed'`, ou logar apenas como **debug/info** pois é um comportamento esperado.
+
+### Opção 1: Não logar casos esperados (Recomendado)
+```typescript
+// No AllExceptionsFilter, antes de logar:
+if (status === HttpStatus.CONFLICT && responseBody.status === 'already_closed') {
+  // Não logar - é comportamento esperado para sincronização mobile
+  this.logger.debug(`[409] Turno já fechado - sincronização mobile: ${request.url}`);
+} else if (status >= 400) {
+  this.logger.warn(`[${status}] ${request.method} ${request.url} - ${JSON.stringify(safeMessage)}`);
+}
+```
+
+### Opção 2: Logar como debug/info
+```typescript
+// Logar como debug ao invés de warn para casos esperados
+if (status === HttpStatus.CONFLICT && responseBody.status === 'already_closed') {
+  this.logger.debug(`[409] Sincronização mobile - turno já fechado: ${responseBody.remoteId}`);
+} else if (status >= 400) {
+  this.logger.warn(`[${status}] ${request.method} ${request.url} - ${JSON.stringify(safeMessage)}`);
+}
+```
+
+## 🎯 Impacto
+
+- **Funcionalidade**: ✅ Nenhum - sistema está funcionando corretamente
+- **Logs**: ⚠️ Logs poluídos com "erros" que são na verdade comportamentos esperados
+- **Monitoramento**: ⚠️ Pode gerar alertas falsos se houver monitoramento baseado em logs de erro
+
+## 📊 Estatísticas
+
+- **Frequência**: Provavelmente comum quando há problemas de conexão no mobile
+- **Gravidade**: Nenhuma - é comportamento esperado
+- **Ação necessária**: Apenas ajustar nível de log
+
+## 🔧 Correção Sugerida
+
+Ajustar o `AllExceptionsFilter` para tratar casos especiais de HTTP 409 que são comportamentos esperados, não erros.
+
+---
+
+**Conclusão**: Sistema funcionando corretamente. O "erro" é apenas um log de um comportamento esperado que deveria ser logado em nível mais baixo (debug/info) ao invés de warning.
+

--- a/DEPLOY_PRODUCTION.md
+++ b/DEPLOY_PRODUCTION.md
@@ -1,0 +1,267 @@
+# 🚀 Guia de Deploy para Produção
+
+## 📋 Checklist Pré-Deploy
+
+Antes de iniciar o deploy, certifique-se de que:
+
+- [ ] Todos os testes passaram
+- [ ] Build local foi concluído com sucesso
+- [ ] Migration foi testada em ambiente de desenvolvimento
+- [ ] Versões foram atualizadas nos `package.json`
+- [ ] Tags foram criadas
+- [ ] Código foi commitado e está no repositório remoto
+
+---
+
+## 🔄 Passo a Passo do Deploy
+
+### 1️⃣ Preparação do Ambiente
+
+```bash
+# 1. Conectar ao servidor de produção
+ssh usuario@servidor-producao
+
+# 2. Navegar para o diretório do projeto
+cd /caminho/para/nexa-oper
+
+# 3. Verificar branch atual
+git branch
+
+# 4. Fazer backup do banco de dados (IMPORTANTE!)
+# Execute o backup antes de qualquer alteração
+mysqldump -u usuario -p nome_banco > backup_$(date +%Y%m%d_%H%M%S).sql
+```
+
+### 2️⃣ Atualizar Código do Repositório
+
+```bash
+# 1. Buscar as últimas alterações do repositório
+git fetch origin
+
+# 2. Verificar as tags disponíveis
+git tag -l | grep -E "(v0.1.1|api-v0.0.2)"
+
+# 3. Fazer checkout da branch principal (ou branch de produção)
+git checkout main  # ou master, ou production
+
+# 4. Fazer pull das alterações
+git pull origin main
+
+# 5. Verificar se as tags estão disponíveis
+git tag -l | tail -5
+```
+
+### 3️⃣ Executar Migration do Banco de Dados
+
+⚠️ **ATENÇÃO**: Esta é a etapa mais crítica. Execute com cuidado!
+
+```bash
+# 1. Verificar se a migration existe
+ls -la packages/db/prisma/models/migrations/20251207200305_add_motorista_to_turno_eletricista/
+
+# 2. Executar a migration
+# Opção A: Usando npm (recomendado)
+npm run db:migrate:deploy
+
+# Opção B: Usando Prisma diretamente
+cd packages/db
+npx prisma migrate deploy
+cd ../..
+
+# 3. Verificar se a migration foi aplicada
+# Conecte ao banco e verifique se a coluna existe:
+mysql -u usuario -p nome_banco -e "DESCRIBE TurnoEletricistas;" | grep motorista
+```
+
+**Resultado esperado**: Deve aparecer a coluna `motorista` do tipo `tinyint(1)` com default `0`
+
+### 4️⃣ Instalar Dependências
+
+```bash
+# 1. Instalar dependências atualizadas
+npm run install:all
+
+# 2. Gerar Prisma Client (se necessário)
+npm run db:generate
+```
+
+### 5️⃣ Build das Aplicações
+
+```bash
+# 1. Limpar builds anteriores
+npm run clean
+
+# 2. Build da API
+npm run api:build
+
+# 3. Build do Web
+npm run web:build
+
+# 4. Verificar se os builds foram bem-sucedidos
+ls -la apps/api/dist/main.js
+ls -la apps/web/.next/BUILD_ID
+```
+
+### 6️⃣ Parar Aplicações em Execução
+
+```bash
+# 1. Parar aplicações usando PM2
+pm2 stop nexa-api
+pm2 stop nexa-web
+
+# 2. Verificar se pararam
+pm2 status
+```
+
+### 7️⃣ Iniciar Aplicações
+
+```bash
+# 1. Iniciar aplicações
+pm2 start ecosystem.config.js
+
+# 2. Verificar status
+pm2 status
+
+# 3. Verificar logs para erros
+pm2 logs nexa-api --lines 50
+pm2 logs nexa-web --lines 50
+```
+
+### 8️⃣ Verificações Pós-Deploy
+
+```bash
+# 1. Verificar se as aplicações estão respondendo
+curl http://localhost:3001/health  # API
+curl http://localhost:3000       # Web
+
+# 2. Verificar logs em tempo real
+pm2 logs --lines 100
+
+# 3. Verificar uso de recursos
+pm2 monit
+```
+
+### 9️⃣ Testes Funcionais
+
+Após o deploy, teste as seguintes funcionalidades:
+
+- [ ] **Login**: Acessar sistema e fazer login
+- [ ] **Turnos**: Verificar se turnos estão sendo listados corretamente
+- [ ] **Ícone de Motorista**: Verificar se aparece nas tabelas de Visão Geral e Histórico
+- [ ] **Relatórios**:
+  - [ ] Acessar "Turnos por Período"
+  - [ ] Verificar se coluna "Motorista" aparece na exportação
+  - [ ] Verificar se "KM de Abertura" aparece na exportação
+  - [ ] Exportar para Excel e verificar formato
+- [ ] **Abertura de Turno (Mobile)**:
+  - [ ] Abrir turno via mobile
+  - [ ] Verificar se campo motorista está sendo salvo
+- [ ] **Justificativas**: Verificar se página de criar justificativa está funcionando
+
+---
+
+## 🔧 Comandos Úteis Durante o Deploy
+
+### Ver logs em tempo real
+```bash
+pm2 logs --lines 200
+```
+
+### Reiniciar uma aplicação específica
+```bash
+pm2 restart nexa-api
+pm2 restart nexa-web
+```
+
+### Ver status detalhado
+```bash
+pm2 describe nexa-api
+pm2 describe nexa-web
+```
+
+### Rollback (se necessário)
+```bash
+# 1. Parar aplicações
+pm2 stop all
+
+# 2. Voltar para versão anterior
+git checkout v0.1.0  # ou tag anterior
+git pull origin main
+
+# 3. Reverter migration (CUIDADO!)
+# Conecte ao banco e execute:
+# ALTER TABLE TurnoEletricistas DROP COLUMN motorista;
+
+# 4. Rebuild e reiniciar
+npm run build
+pm2 restart all
+```
+
+---
+
+## ⚠️ Problemas Comuns e Soluções
+
+### Problema: Migration falha
+**Solução**:
+- Verificar se há conexão com o banco
+- Verificar permissões do usuário do banco
+- Verificar se a tabela existe
+
+### Problema: Build falha
+**Solução**:
+- Verificar logs de erro
+- Limpar node_modules e reinstalar: `npm run reset`
+- Verificar se todas as dependências estão instaladas
+
+### Problema: Aplicação não inicia
+**Solução**:
+- Verificar logs: `pm2 logs --err`
+- Verificar variáveis de ambiente
+- Verificar se a porta está disponível
+- Verificar permissões de arquivos
+
+### Problema: Campo motorista não aparece
+**Solução**:
+- Verificar se migration foi executada: `DESCRIBE TurnoEletricistas;`
+- Verificar se Prisma Client foi regenerado: `npm run db:generate`
+- Reiniciar aplicações: `pm2 restart all`
+
+---
+
+## 📝 Checklist Final
+
+Após o deploy, confirme:
+
+- [ ] Migration executada com sucesso
+- [ ] Builds concluídos sem erros
+- [ ] Aplicações iniciadas e rodando
+- [ ] Logs sem erros críticos
+- [ ] Funcionalidades testadas e funcionando
+- [ ] Performance normal
+- [ ] Backup do banco criado
+
+---
+
+## 🆘 Suporte
+
+Em caso de problemas:
+
+1. **Verificar logs**: `pm2 logs --lines 500`
+2. **Verificar status**: `pm2 status`
+3. **Verificar banco**: Conectar e verificar dados
+4. **Rollback**: Seguir procedimento de rollback acima
+
+---
+
+## 📊 Resumo das Versões
+
+- **Web**: `v0.1.1` → Campo Motorista e Melhorias nos Relatórios
+- **API**: `api-v0.0.2` → Campo Motorista na Tabela TurnoEletricistas
+- **Migration**: `20251207200305_add_motorista_to_turno_eletricista`
+
+---
+
+**Data do Deploy**: _______________
+**Responsável**: _______________
+**Status**: ☐ Sucesso | ☐ Com Problemas | ☐ Rollback
+

--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,0 +1,138 @@
+# 🚀 Adição de Campo Motorista e Melhorias nos Relatórios
+
+## 📋 Resumo
+
+Esta PR adiciona o campo `motorista` na tabela `TurnoEletricistas` para identificar qual eletricista é o motorista do turno, além de melhorias nos relatórios e correções de bugs.
+
+## ✨ Principais Alterações
+
+### 🗄️ Banco de Dados
+
+- **Adicionado campo `motorista` (boolean, default: false)** na tabela `TurnoEletricistas`
+- **Migration criada**: `20251207200305_add_motorista_to_turno_eletricista`
+  - Campo com valor padrão `false` para não afetar dados existentes
+  - Compatível com dados históricos
+
+### 🔧 Backend (API)
+
+- **DTOs atualizados**:
+  - `EletricistaTurnoDto` agora inclui campo `motorista?: boolean`
+  - Campo opcional para manter compatibilidade
+
+- **Controller Mobile**:
+  - Mapeamento do campo `motorista` do DTO mobile para o DTO padrão
+  - Informação de motorista agora é preservada na abertura de turno
+
+- **Service de Turnos**:
+  - Salvamento do campo `motorista` ao criar `TurnoEletricistas`
+  - Valor padrão `false` para turnos criados pelo backoffice
+
+### 🌐 Frontend (Web)
+
+- **Repositório**:
+  - `TurnoRepository` atualizado para incluir `motorista` no mapeamento de eletricistas
+  - Campo disponível em todas as consultas de turnos
+
+- **Relatórios**:
+  - `getTurnosPorPeriodo` atualizado para buscar e retornar campo `motorista`
+  - Relatório "Turnos por Período" agora usa campo da tabela ao invés de verificar pelo cargo
+  - Exportação Excel inclui coluna "Motorista" (Sim/Não)
+
+- **Interface do Usuário**:
+  - **Ícone de carro** (`CarOutlined`) adicionado ao lado do nome do eletricista motorista
+  - Implementado nas tabelas de:
+    - Visão Geral de Turnos (`/dashboard/turnos`)
+    - Histórico de Turnos (`/dashboard/historico`)
+  - Tooltip atualizado para indicar "Motorista" quando aplicável
+
+### 📊 Melhorias nos Relatórios
+
+- **Relatório "Turnos por Período"**:
+  - Campo "KM de Abertura" adicionado na exportação
+  - Campo "Motorista" (Sim/Não) adicionado na exportação
+  - Campos de data e hora combinados para evitar confusão em turnos que cruzam dias
+  - Formato: "Hora Abertura (Data e Hora)" e "Hora Final (Data e Hora)"
+
+### 🐛 Correções de Bugs
+
+- Corrigido erro de importação em `criarJustificativa.ts` (caminhos relativos)
+- Corrigido erro de tipo em `justificativas-equipe/criar/page.tsx` (propriedade `items`)
+- Corrigido erro de query Prisma em `relatoriosTurnos.ts` (mistura de `select` e `include`)
+- Ajustado filtro de eletricista no relatório para retornar sempre boolean
+
+### 📦 Versionamento
+
+- **Web**: `0.1.0` → `0.1.1`
+- **API**: `0.0.1` → `0.0.2`
+
+## 🔍 Detalhes Técnicos
+
+### Migration
+
+```sql
+ALTER TABLE `TurnoEletricistas` ADD COLUMN `motorista` BOOLEAN NOT NULL DEFAULT false;
+```
+
+### Estrutura de Dados
+
+```typescript
+interface TurnoEletricista {
+  id: number;
+  turnoId: number;
+  eletricistaId: number;
+  motorista: boolean; // ← Novo campo
+  // ... outros campos
+}
+```
+
+### Fluxo de Dados
+
+1. **Mobile** → Envia `motorista: boolean` no `EletricistaMobileDto`
+2. **Controller** → Mapeia para `EletricistaTurnoDto` com campo `motorista`
+3. **Service** → Salva no banco ao criar `TurnoEletricista`
+4. **Repository** → Retorna campo `motorista` em todas as consultas
+5. **Frontend** → Exibe ícone de carro quando `motorista === true`
+
+## ✅ Testes Realizados
+
+- ✅ Build do Web concluído com sucesso
+- ✅ Build da API concluído com sucesso
+- ✅ Type-check passou em ambos os projetos
+- ✅ Linter sem erros críticos
+- ✅ Migration testada (campo com default false)
+
+## 📝 Notas de Migração
+
+- **Compatibilidade**: Totalmente compatível com dados existentes
+- **Valor padrão**: Todos os registros existentes terão `motorista = false`
+- **Novos turnos**: Campo será preenchido corretamente a partir de agora
+- **Dados históricos**: Podem ser atualizados manualmente se necessário
+
+## 🎯 Impacto
+
+- **Usuários**: Agora podem identificar visualmente quem é o motorista em cada turno
+- **Relatórios**: Informação de motorista disponível para análise e exportação
+- **Dados**: Informação de motorista preservada desde a abertura do turno
+- **Performance**: Sem impacto negativo (campo indexável se necessário no futuro)
+
+## 📸 Screenshots
+
+### Antes
+- Eletricistas listados sem identificação de motorista
+- Relatórios sem informação de motorista
+
+### Depois
+- Ícone de carro azul ao lado do nome do motorista
+- Coluna "Motorista" no relatório exportado
+- Tooltip indicando "Motorista" ao passar o mouse
+
+## 🔗 Issues Relacionadas
+
+- Implementação do campo motorista na tabela TurnoEletricista
+- Melhoria na identificação visual de motoristas
+- Adição de informações de motorista nos relatórios
+
+---
+
+**Versões**: Web `0.1.1` | API `0.0.2`
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,101 @@
+# 🏷️ Release Notes
+
+## 📦 Versões
+
+### Web: `v0.1.1`
+### API: `v0.0.2`
+
+---
+
+## 🚀 Web v0.1.1
+
+### ✨ Novas Funcionalidades
+
+- **Campo Motorista**: Identificação visual de motoristas nas tabelas de turnos
+  - Ícone de carro azul ao lado do nome do motorista
+  - Implementado em Visão Geral e Histórico de Turnos
+  - Tooltip indicando "Motorista" ao passar o mouse
+
+- **Melhorias nos Relatórios**:
+  - Campo "KM de Abertura" adicionado na exportação
+  - Campo "Motorista" (Sim/Não) adicionado na exportação
+  - Campos de data e hora combinados para evitar confusão
+  - Formato: "Hora Abertura (Data e Hora)" e "Hora Final (Data e Hora)"
+
+### 🐛 Correções
+
+- Corrigido erro de importação em `criarJustificativa.ts`
+- Corrigido erro de tipo em `justificativas-equipe/criar/page.tsx`
+- Corrigido erro de query Prisma em `relatoriosTurnos.ts`
+- Ajustado filtro de eletricista no relatório
+
+### 📊 Melhorias
+
+- Relatórios agora usam campo `motorista` da tabela ao invés de verificar pelo cargo
+- Informação de motorista preservada desde a abertura do turno
+
+---
+
+## 🔧 API v0.0.2
+
+### ✨ Novas Funcionalidades
+
+- **Campo Motorista na Tabela TurnoEletricistas**:
+  - Campo `motorista` (boolean, default: false) adicionado
+  - Migration criada: `20251207200305_add_motorista_to_turno_eletricista`
+  - Compatível com dados existentes
+
+### 🔄 Alterações
+
+- **DTOs Atualizados**:
+  - `EletricistaTurnoDto` agora inclui campo `motorista?: boolean`
+  - Campo opcional para manter compatibilidade
+
+- **Controller Mobile**:
+  - Mapeamento do campo `motorista` do DTO mobile para o DTO padrão
+  - Informação de motorista preservada na abertura de turno
+
+- **Service de Turnos**:
+  - Salvamento do campo `motorista` ao criar `TurnoEletricistas`
+  - Valor padrão `false` para turnos criados pelo backoffice
+
+### 📝 Notas de Migração
+
+- **Compatibilidade**: Totalmente compatível com dados existentes
+- **Valor padrão**: Todos os registros existentes terão `motorista = false`
+- **Novos turnos**: Campo será preenchido corretamente a partir de agora
+
+---
+
+## 🔗 Comandos para Criar Tags
+
+```bash
+# Tag para Web
+git tag -a v0.1.1 -m "Web v0.1.1: Campo Motorista e Melhorias nos Relatórios"
+
+# Tag para API
+git tag -a api-v0.0.2 -m "API v0.0.2: Campo Motorista na Tabela TurnoEletricistas"
+
+# Push das tags
+git push origin v0.1.1
+git push origin api-v0.0.2
+```
+
+---
+
+## 📋 Checklist de Release
+
+- [x] Build do Web concluído com sucesso
+- [x] Build da API concluído com sucesso
+- [x] Type-check passou em ambos os projetos
+- [x] Migration testada
+- [x] Versões atualizadas nos package.json
+- [ ] Tags criadas
+- [ ] Tags enviadas para o repositório remoto
+- [ ] Release notes publicadas
+
+---
+
+**Data**: 2025-12-07
+**Autor**: Sistema Nexa Oper
+

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -61,7 +61,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
-    "eslint": "^9.18.0",
+    "eslint": "8.57.1",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.0.0",

--- a/apps/api/src/common/filters/all-exceptions.filter.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.ts
@@ -171,11 +171,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
       this.logger.error(`[500] ${request.method} ${request.url} - ${errorMessage}`, errorStack);
     } else if (status >= 400) {
       // Casos especiais que são comportamentos esperados, não erros
-      const isExpectedBehavior = 
-        status === HttpStatus.CONFLICT && 
-        typeof responseBody === 'object' && 
+      // HTTP 409 com status 'already_closed' é comportamento esperado para sincronização mobile
+      const isExpectedBehavior =
+        status === HttpStatus.CONFLICT &&
+        typeof responseBody === 'object' &&
+        responseBody !== null &&
         responseBody.status === 'already_closed';
-      
+
       if (isExpectedBehavior) {
         // Logar como debug - é comportamento esperado para sincronização mobile
         this.logger.debug(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,10 +26,10 @@
     "bcryptjs": "^3.0.2",
     "dotenv": "^16.6.1",
     "leaflet": "^1.9.4",
-    "next": "15.5.2",
+    "next": "^15.5.7",
     "next-auth": "^4.24.11",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
     "react-leaflet": "^5.0.0",
     "swr": "^2.3.6",
     "zod": "^4.1.5"
@@ -40,7 +40,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.5.2",
+    "eslint-config-next": "^15.5.7",
     "rimraf": "^6.0.1",
     "typescript": "^5"
   }

--- a/apps/web/src/lib/actions/turno-realizado/reconciliarManual.ts
+++ b/apps/web/src/lib/actions/turno-realizado/reconciliarManual.ts
@@ -1,0 +1,73 @@
+/**
+ * Server Action para executar reconciliação manual de turnos
+ */
+
+'use server';
+
+import { handleServerAction } from '../common/actionHandler';
+import { z } from 'zod';
+
+const reconciliarManualSchema = z.object({
+  dataReferencia: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Data deve estar no formato YYYY-MM-DD'),
+  equipeId: z.number().int().positive().optional(),
+  todasEquipes: z.boolean(),
+});
+
+/**
+ * Executa reconciliação manual de turnos
+ *
+ * Esta Server Action faz a requisição para a API do servidor Next.js,
+ * que é visto como localhost pela API, permitindo que o LocalhostCorsGuard
+ * permita o acesso mesmo em produção.
+ *
+ * @param rawData - Dados brutos do formulário
+ * @returns Resultado da reconciliação da API
+ */
+export const reconciliarManual = async (rawData: unknown) =>
+  handleServerAction(
+    reconciliarManualSchema,
+    async (data, session) => {
+      const baseUrl =
+        process.env.NEXT_PUBLIC_API_URL ||
+        (process.env.NODE_ENV === 'development' ? 'http://localhost:3001' : '');
+
+      if (!baseUrl) {
+        throw new Error('NEXT_PUBLIC_API_URL não está configurada');
+      }
+
+      // Validar que se não for todasEquipes, equipeId deve estar presente
+      if (!data.todasEquipes && !data.equipeId) {
+        throw new Error('equipeId é obrigatório quando todasEquipes não é true');
+      }
+
+      const body: any = {
+        dataReferencia: data.dataReferencia,
+        todasEquipes: data.todasEquipes,
+      };
+
+      if (!data.todasEquipes && data.equipeId) {
+        body.equipeId = data.equipeId;
+      }
+
+      // Fazer requisição do servidor (vem de localhost, então passa no LocalhostCorsGuard)
+      const response = await fetch(`${baseUrl}/api/turnos-realizados/reconciliacao/manual`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      const responseData = await response.json();
+
+      if (!response.ok) {
+        throw new Error(responseData.message || `Erro ${response.status}: ${response.statusText}`);
+      }
+
+      // Retornar exatamente o mesmo formato que a API retorna
+      return responseData;
+    },
+    rawData,
+    { entityName: 'TurnoRealizado', actionType: 'create' }
+  );
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       }
     },
     "apps/api": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -72,7 +72,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
-        "eslint": "^9.18.0",
+        "eslint": "8.57.1",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
         "globals": "^16.0.0",
@@ -147,6 +147,86 @@
         "undici-types": "~6.21.0"
       }
     },
+    "apps/api/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/api/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "apps/api/node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "apps/api/node_modules/eslint-config-prettier": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
@@ -177,6 +257,114 @@
         "node": ">=8.0.0"
       }
     },
+    "apps/api/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "apps/api/node_modules/eslint/node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "apps/api/node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "apps/api/node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "apps/api/node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "apps/api/node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "apps/api/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "apps/api/node_modules/estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
@@ -185,6 +373,73 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "apps/api/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "apps/api/node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "apps/api/node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apps/api/node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "apps/api/node_modules/globals": {
@@ -211,6 +466,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "apps/api/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "apps/api/node_modules/ts-node": {
@@ -270,6 +538,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "apps/api/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "apps/api/node_modules/typescript": {
@@ -337,7 +618,7 @@
     },
     "apps/web": {
       "name": "@nexa-oper/web",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@ant-design/nextjs-registry": "^1.1.0",
         "@ant-design/plots": "^2.6.5",
@@ -353,10 +634,10 @@
         "bcryptjs": "^3.0.2",
         "dotenv": "^16.6.1",
         "leaflet": "^1.9.4",
-        "next": "15.5.2",
+        "next": "^15.5.7",
         "next-auth": "^4.24.11",
-        "react": "19.1.0",
-        "react-dom": "19.1.0",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
         "react-leaflet": "^5.0.0",
         "swr": "^2.3.6",
         "zod": "^4.1.5"
@@ -367,7 +648,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "15.5.2",
+        "eslint-config-next": "^15.5.7",
         "rimraf": "^6.0.1",
         "typescript": "^5"
       }
@@ -2897,6 +3178,22 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -2910,6 +3207,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
@@ -4871,15 +5176,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
-      "integrity": "sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
+      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.2.tgz",
-      "integrity": "sha512-lkLrRVxcftuOsJNhWatf1P2hNVfh98k/omQHrCEPPriUypR6RcS13IvLdIrEvkm9AH2Nu2YpR5vLqBuy6twH3Q==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.7.tgz",
+      "integrity": "sha512-DtRU2N7BkGr8r+pExfuWHwMEPX5SD57FeA6pxdgCHODo+b/UgIgjE+rgWKtJAbEbGhVZ2jtHn4g3wNhWFoNBQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4887,9 +5192,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.2.tgz",
-      "integrity": "sha512-8bGt577BXGSd4iqFygmzIfTYizHb0LGWqH+qgIF/2EDxS5JsSdERJKA8WgwDyNBZgTIIA4D8qUtoQHmxIIquoQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
+      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
       "cpu": [
         "arm64"
       ],
@@ -4903,9 +5208,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.2.tgz",
-      "integrity": "sha512-2DjnmR6JHK4X+dgTXt5/sOCu/7yPtqpYt8s8hLkHFK3MGkka2snTv3yRMdHvuRtJVkPwCGsvBSwmoQCHatauFQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
+      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
       "cpu": [
         "x64"
       ],
@@ -4919,9 +5224,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.2.tgz",
-      "integrity": "sha512-3j7SWDBS2Wov/L9q0mFJtEvQ5miIqfO4l7d2m9Mo06ddsgUK8gWfHGgbjdFlCp2Ek7MmMQZSxpGFqcC8zGh2AA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
+      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
       "cpu": [
         "arm64"
       ],
@@ -4935,9 +5240,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.2.tgz",
-      "integrity": "sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
+      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
       "cpu": [
         "arm64"
       ],
@@ -4951,9 +5256,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.2.tgz",
-      "integrity": "sha512-o1RV/KOODQh6dM6ZRJGZbc+MOAHww33Vbs5JC9Mp1gDk8cpEO+cYC/l7rweiEalkSm5/1WGa4zY7xrNwObN4+Q==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
+      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
       "cpu": [
         "x64"
       ],
@@ -4967,9 +5272,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.2.tgz",
-      "integrity": "sha512-/VUnh7w8RElYZ0IV83nUcP/J4KJ6LLYliiBIri3p3aW2giF+PAVgZb6mk8jbQSB3WlTai8gEmCAr7kptFa1H6g==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
+      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
       "cpu": [
         "x64"
       ],
@@ -4983,9 +5288,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.2.tgz",
-      "integrity": "sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
+      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
       "cpu": [
         "arm64"
       ],
@@ -4999,9 +5304,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.2.tgz",
-      "integrity": "sha512-W5VvyZHnxG/2ukhZF/9Ikdra5fdNftxI6ybeVKYvBPDtyx7x4jPPSNduUkfH5fo3zG0JQ0bPxgy41af2JX5D4Q==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
+      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
       "cpu": [
         "x64"
       ],
@@ -10128,13 +10433,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.2.tgz",
-      "integrity": "sha512-3hPZghsLupMxxZ2ggjIIrat/bPniM2yRpsVPVM40rp8ZMzKWOJp2CGWn7+EzoV2ddkUr5fxNfHpF+wU1hGt/3g==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.7.tgz",
+      "integrity": "sha512-nU/TRGHHeG81NeLW5DeQT5t6BDUqbpsNQTvef1ld/tqHT+/zTx60/TIhKnmPISTTe++DVo+DLxDmk4rnwHaZVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.2",
+        "@next/eslint-plugin-next": "15.5.7",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -12322,6 +12627,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14765,12 +15080,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
-      "integrity": "sha512-H8Otr7abj1glFhbGnvUt3gz++0AF1+QoCXEBmd/6aKbfdFwrn0LpA836Ed5+00va/7HQSDD+mOoVhn3tNy3e/Q==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
+      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.2",
+        "@next/env": "15.5.7",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -14783,14 +15098,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.2",
-        "@next/swc-darwin-x64": "15.5.2",
-        "@next/swc-linux-arm64-gnu": "15.5.2",
-        "@next/swc-linux-arm64-musl": "15.5.2",
-        "@next/swc-linux-x64-gnu": "15.5.2",
-        "@next/swc-linux-x64-musl": "15.5.2",
-        "@next/swc-win32-arm64-msvc": "15.5.2",
-        "@next/swc-win32-x64-msvc": "15.5.2",
+        "@next/swc-darwin-arm64": "15.5.7",
+        "@next/swc-darwin-x64": "15.5.7",
+        "@next/swc-linux-arm64-gnu": "15.5.7",
+        "@next/swc-linux-arm64-musl": "15.5.7",
+        "@next/swc-linux-x64-gnu": "15.5.7",
+        "@next/swc-linux-x64-musl": "15.5.7",
+        "@next/swc-win32-arm64-msvc": "15.5.7",
+        "@next/swc-win32-x64-msvc": "15.5.7",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -16566,24 +16881,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-is": {
@@ -17123,9 +17438,9 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/schema-utils": {
@@ -18387,6 +18702,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",


### PR DESCRIPTION
update Versions do recai, corrigindo vulnerabilidades

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches manual reconciliation to a Server Action on web, adjusts API exception filter to log expected 409 already_closed as debug, and updates app versions/dependencies; adds deployment and release documentation.
> 
> - **Backend/API**:
>   - Refines `AllExceptionsFilter` to treat HTTP `409` with `status: 'already_closed'` as debug (not warning).
>   - Bumps `apps/api` version to `0.0.2`; aligns dev deps (`eslint@8.57.1`).
> - **Web**:
>   - Manual reconciliation page (`/dashboard/frequencia/reconciliacao-manual/page.tsx`): uses `Server Action` (`reconciliarManual`) instead of direct fetch, adds client-side validation and info messaging.
>   - Adds `apps/web/src/lib/actions/turno-realizado/reconciliarManual.ts` with Zod validation and server-side request to API.
>   - Updates `apps/web` deps (Next `^15.5.7`, React `^19.2.1`) and bumps version to `0.1.1`.
> - **Docs**:
>   - Adds `ANALISE_ERRO_PRODUCAO.md` explaining expected 409 behavior and logging.
>   - Adds `DEPLOY_PRODUCTION.md`, `PULL_REQUEST.md`, and `RELEASE_NOTES.md` with release steps and notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5e1a7959b2b186d9b6b8dd7565e7eacd96bb356. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->