### PR TITLE
Desenvolvimento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+## [Unreleased]
+
+### 🎯 Novas Funcionalidades
+
+#### 📋 Consulta de Checklists
+
+Adicionada nova página **"Consulta Checklists"** no menu Segurança, permitindo busca avançada e visualização completa de checklists preenchidos.
+
+**Funcionalidades da Listagem:**
+- **Filtros disponíveis:**
+  - Período (data início e fim) - padrão: mês atual
+  - Tipo de equipe
+  - Equipe (filtrado por tipo de equipe selecionado)
+  - Placa do veículo (busca parcial)
+  - Eletricista
+  - Base
+  - Tipo de checklist
+  - Checklist específico (filtrado por tipo de checklist selecionado)
+  
+- **Listagem com informações resumidas:**
+  - ID do checklist
+  - Data e hora do preenchimento
+  - Nome do checklist e tipo
+  - Dados do eletricista (nome e matrícula)
+  - Informações da equipe e tipo
+  - Dados do veículo (placa e modelo)
+  - Quantidade de respostas
+  
+- **Recursos:**
+  - Paginação funcional
+  - Botão "Limpar Filtros" para reset rápido
+  - Botão "Ver" para acessar detalhes completos
+  - Tabela responsiva com scroll horizontal
+
+**Página de Detalhes do Checklist:**
+- **Informações gerais:**
+  - Dados completos do checklist (nome, tipo, data, hora)
+  - Informações do eletricista (nome e matrícula)
+  - Dados do turno (equipe, tipo de equipe, veículo)
+  - Localização geográfica (latitude/longitude), se disponível
+
+- **Visualização de respostas:**
+  - Todas as perguntas e respostas do checklist
+  - Status de cada resposta (respondido, com foto, aguardando foto)
+  - Indicação de respostas que geram pendência
+  - Data e hora de cada resposta
+  
+- **Gerenciamento de fotos:**
+  - Visualização de todas as fotos associadas às respostas
+  - Preview com zoom
+  - Informações de tamanho e data de sincronização
+  - Suporte para múltiplas fotos por resposta
+
+#### 📊 Melhorias no Relatório de Segurança
+
+Adicionado filtro por **Tipo de Equipe** no relatório de checklist, permitindo filtrar os dados de reprovas por tipo específico de equipe.
+
+- O filtro funciona em conjunto com o filtro de base existente
+- Aplicado aos três gráficos:
+  - Top 10 Perguntas com Mais Reprovas
+  - Top 10 Equipes com Mais Reprovas
+  - Reprovas por Tipo de Checklist
+
+### 🔧 Melhorias Técnicas
+
+#### Server Actions
+
+- **`listChecklistsPreenchidos`**: Nova action para buscar checklists preenchidos com filtros avançados e paginação
+- **`getChecklistPreenchidoById`**: Nova action para buscar detalhes completos de um checklist específico
+- **Atualização das actions de relatório**: Todas as três actions (`getReprovasPorPergunta`, `getReprovasPorEquipe`, `getReprovasPorTipoChecklist`) agora suportam filtro por tipo de equipe
+
+#### Correções de Tipos
+
+- Correção de conversão de tipos `null` para `undefined` nas interfaces TypeScript
+- Conversão adequada de objetos `Date` para strings ISO
+- Ajustes de compatibilidade entre tipos do Prisma e interfaces do frontend
+
+### 🎨 Melhorias de UX
+
+- Interface intuitiva com filtros organizados em grid responsivo
+- Feedback visual claro sobre status de respostas e pendências
+- Navegação fluida entre listagem e detalhes
+- Informações organizadas em cards e colapsos para melhor visualização
+
+### 📝 Notas
+
+- Todos os filtros são opcionais e podem ser combinados
+- A paginação padrão é de 20 itens por página
+- As buscas por placa de veículo são case-insensitive e suportam busca parcial
+- Os dados são atualizados automaticamente quando os filtros são alterados
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Adicionada nova página **"Consulta Checklists"** no menu Segurança, permitindo
   - Base
   - Tipo de checklist
   - Checklist específico (filtrado por tipo de checklist selecionado)
-  
+
 - **Listagem com informações resumidas:**
   - ID do checklist
   - Data e hora do preenchimento
@@ -27,7 +27,7 @@ Adicionada nova página **"Consulta Checklists"** no menu Segurança, permitindo
   - Informações da equipe e tipo
   - Dados do veículo (placa e modelo)
   - Quantidade de respostas
-  
+
 - **Recursos:**
   - Paginação funcional
   - Botão "Limpar Filtros" para reset rápido
@@ -46,7 +46,7 @@ Adicionada nova página **"Consulta Checklists"** no menu Segurança, permitindo
   - Status de cada resposta (respondido, com foto, aguardando foto)
   - Indicação de respostas que geram pendência
   - Data e hora de cada resposta
-  
+
 - **Gerenciamento de fotos:**
   - Visualização de todas as fotos associadas às respostas
   - Preview com zoom

--- a/apps/web/src/app/dashboard/cadastro/escala-equipe-periodo/wizard.tsx
+++ b/apps/web/src/app/dashboard/cadastro/escala-equipe-periodo/wizard.tsx
@@ -462,34 +462,50 @@ export default function EscalaWizard({ onFinish, onCancel }: EscalaWizardProps) 
                   key: 'matricula',
                   width: 120,
                 },
-                // ✅ CORREÇÃO: Mostrar coluna "1º Dia de Folga" apenas para escalas CICLO_DIAS
+                // ✅ Mostrar coluna "1º Dia de Folga" para escalas CICLO_DIAS
                 // Para SEMANA_DEPENDENTE (espanhola), a folga é determinada pela semana e dia da semana
-                ...(tipoEscalaSelecionado?.modoRepeticao === 'CICLO_DIAS'
-                  ? [
-                      {
-                        title: '1º Dia de Folga',
-                        key: 'primeiroDiaFolga',
-                        width: 150,
-                        render: (_: unknown, record: any) => {
-                          const eletricistaConfig = eletricistasEscala.find(
-                            (e) => e.eletricistaId === record.id
-                          );
-                          if (!eletricistaConfig) return null;
+                {
+                  title: '1º Dia de Folga',
+                  key: 'primeiroDiaFolga',
+                  width: 150,
+                  render: (_: unknown, record: any) => {
+                    const eletricistaConfig = eletricistasEscala.find(
+                      (e) => e.eletricistaId === record.id
+                    );
 
-                          return (
-                            <InputNumber
-                              min={0}
-                              placeholder="Ex: 2"
-                              value={eletricistaConfig.primeiroDiaFolga}
-                              onChange={(value) => updatePrimeiroDiaFolga(record.id, value || 0)}
-                              style={{ width: '100%' }}
-                              addonAfter="dias"
-                            />
-                          );
-                        },
-                      },
-                    ]
-                  : []),
+                    // Se não está selecionado, não mostra nada
+                    if (!eletricistaConfig) return null;
+
+                    // Se é escala SEMANA_DEPENDENTE, mostra como desabilitado com tooltip
+                    const isSemanaDependente = tipoEscalaSelecionado?.modoRepeticao === 'SEMANA_DEPENDENTE';
+
+                    if (isSemanaDependente) {
+                      return (
+                        <InputNumber
+                          min={0}
+                          placeholder="N/A"
+                          value={0}
+                          disabled
+                          style={{ width: '100%' }}
+                          addonAfter="dias"
+                          title="Para escalas semana dependente, a folga é determinada automaticamente pela semana e dia da semana"
+                        />
+                      );
+                    }
+
+                    // Para CICLO_DIAS, permite edição
+                    return (
+                      <InputNumber
+                        min={0}
+                        placeholder="Ex: 2"
+                        value={eletricistaConfig.primeiroDiaFolga}
+                        onChange={(value) => updatePrimeiroDiaFolga(record.id, value || 0)}
+                        style={{ width: '100%' }}
+                        addonAfter="dias"
+                      />
+                    );
+                  },
+                },
               ]}
             />
 

--- a/apps/web/src/lib/services/escala/EscalaEquipePeriodoService.ts
+++ b/apps/web/src/lib/services/escala/EscalaEquipePeriodoService.ts
@@ -209,13 +209,23 @@ export class EscalaEquipePeriodoService extends AbstractCrudService<
       throw new Error('Nenhum eletricista selecionado para a escala');
     }
 
+    // ✅ CORREÇÃO: Permitir flexibilidade na quantidade de eletricistas
+    // O eletricistasPorTurma do tipo de escala é apenas uma referência,
+    // mas permite usar menos eletricistas se necessário (ex: 4x2 com 2 ao invés de 3)
     const eletricistasPorTurma =
       tipoEscala.eletricistasPorTurma || eletricistasParaGerar.length;
 
-    // Validar se há eletricistas suficientes
-    if (eletricistasParaGerar.length < eletricistasPorTurma) {
-      throw new Error(
-        `Foram selecionados apenas ${eletricistasParaGerar.length} eletricista(s), mas o tipo de escala requer ${eletricistasPorTurma} por turma`
+    // Validar apenas se não houver nenhum eletricista selecionado
+    // A quantidade mínima será determinada pela quantidade selecionada
+    if (eletricistasParaGerar.length === 0) {
+      throw new Error('Nenhum eletricista selecionado para a escala');
+    }
+
+    // Aviso (não erro) se usar menos eletricistas que o recomendado
+    if (tipoEscala.eletricistasPorTurma && eletricistasParaGerar.length < tipoEscala.eletricistasPorTurma) {
+      // Apenas log, não bloqueia - permite flexibilidade
+      console.warn(
+        `Aviso: Tipo de escala "${tipoEscala.nome}" recomenda ${tipoEscala.eletricistasPorTurma} eletricista(s), mas foram selecionados ${eletricistasParaGerar.length}. A escala será gerada com a quantidade selecionada.`
       );
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds checklist consultation features and updates escala wizard/service to allow fewer electricians while refining first-day-off handling.
> 
> - **Docs**:
>   - Add `CHANGELOG.md` detailing new Segurança checklist consultation, report filter by team type, server actions, TS type fixes, and UX improvements.
> - **Frontend (wizard `apps/web/src/app/dashboard/cadastro/escala-equipe-periodo/wizard.tsx`)**:
>   - Always show `1º Dia de Folga` column; for `SEMANA_DEPENDENTE` display disabled input with tooltip; keep editable for `CICLO_DIAS`.
> - **Backend (`EscalaEquipePeriodoService.ts`)**:
>   - Relax `eletricistasPorTurma` validation: allow generating with fewer electricians; only error when none selected; log warning instead of blocking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3fa432e7ffb7bd8288a13965bc0a0c322e882b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->